### PR TITLE
Fix URL for Julia Programming Language

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to course 18.330 at MIT! This is an introductory course on **numerical a
 
 ## Installation of required software 
 We will be using the following **free / open source** software:
-- The [Julia language](www.julialang.org)
+- The [Julia language](https://www.julialang.org)
 - The [Pluto notebook](https://github.com/fonsp/Pluto.jl) environment
 
 Please follow [these  instructions](https://computationalthinking.mit.edu/Spring21/installation/) to install Julia and then Pluto.


### PR DESCRIPTION
Hi folks, I noticed a broken URL in the README

![Screen Shot 2021-07-06 at 8 13 25 PM](https://user-images.githubusercontent.com/6121530/124620136-d716fa00-de96-11eb-9c79-eb10665c6122.png)

Markdown needs `https`

more info on this StackOverflow Question https://meta.stackexchange.com/questions/121293/markdown-support-for-urls-without-a-protocol